### PR TITLE
Implement ESX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This allows players to keep their HUD preferences after reconnecting or restarti
 | --- | --- |
 | QBox / `qbx_core` | Supported |
 | QBCore / `qb-core` | Supported |
+| ESX / `es_extended` | Supported |
 
 The resource automatically loads the appropriate framework bridge depending on which framework is running.
 
@@ -125,6 +126,7 @@ The nitrous integration is isolated and can easily be changed to support another
 - One of the supported frameworks:
   - `qbx_core`
   - `qb-core`
+  - `es_extended`
 - `ox_lib`
 - A compiled frontend build
 
@@ -178,6 +180,13 @@ ensure qb-core
 ensure element_hud
 ```
 
+For ESX:
+
+```cfg
+ensure ox_lib
+ensure es_extended
+ensure element_hud
+```
 
 The exact configuration structure may differ depending on the current version of the resource.
 
@@ -190,7 +199,8 @@ The framework-specific logic is separated into bridge modules.
 ```text
 bridge/
 ├── qb.lua
-└── qbx.lua
+├── qbx.lua
+└── esx.lua
 ```
 
 This keeps the main HUD logic framework-independent and makes it easier to add support for other frameworks later.

--- a/bridge/bridge.lua
+++ b/bridge/bridge.lua
@@ -4,6 +4,8 @@ if GetResourceState('qbx_core') == 'started' then
     Bridge = require 'bridge.qbx'
 elseif GetResourceState('qb-core') == 'started' then
     Bridge = require 'bridge.qb'
+elseif GetResourceState('es_extended') == 'started' then
+    Bridge = require 'bridge.esx'
 else
     lib.print.warn('No supported framework found')
     Bridge = {}

--- a/bridge/esx.lua
+++ b/bridge/esx.lua
@@ -1,0 +1,52 @@
+if GetResourceState('es_extended') ~= 'started' then
+    return {}
+end
+
+lib.print.info('Loading ESX bridge')
+
+local ESX = exports.es_extended:getSharedObject()
+local Bridge = {}
+local playerData = ESX.GetPlayerData() or {}
+
+RegisterNetEvent('esx:playerLoaded', function(xPlayer)
+    if source == '' or source == 0 or type(xPlayer) ~= 'table' then return end
+
+    playerData = xPlayer
+end)
+
+RegisterNetEvent('esx:onPlayerLogout', function()
+    if source == '' or source == 0 then return end
+
+    playerData = {}
+end)
+
+AddEventHandler('esx:setPlayerData', function(key, value)
+    if GetInvokingResource() ~= 'es_extended' then return end
+
+    playerData[key] = value
+end)
+
+local needs = { hunger = 100, thirst = 100 }
+
+AddEventHandler('esx_status:onTick', function(status)
+    for i = 1, #status do
+        local entry = status[i]
+
+        if needs[entry.name] ~= nil and type(entry.percent) == 'number' then
+            needs[entry.name] = math.floor(entry.percent + 0.5)
+        end
+    end
+end)
+
+function Bridge.GetPlayerData()
+    if next(playerData) == nil then return {} end
+
+    local metadata = playerData.metadata or {}
+    metadata.hunger = needs.hunger
+    metadata.thirst = needs.thirst
+    playerData.metadata = metadata
+
+    return playerData
+end
+
+return Bridge


### PR DESCRIPTION
This PR adds support for the ESX framework, I created a new file in the bridge folder and listened for the `esx_status:onTick` event then converted the data into a table called needs so that we return the same format with `Bridge.GetPlayerData` even though esx does stuff *differently*

## Testing
1. Added resource to my ESX test server
2. loaded in game and had no errors
3. UI displays as expected